### PR TITLE
Add responsive layout for tarot cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Выбор карт</title>
   <style>
     body {
@@ -16,13 +17,13 @@
     }
     .cards {
       display: grid;
-      grid-template-columns: repeat(3, 100px);
+      grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
       gap: 10px;
       justify-content: center;
     }
     .card {
-      width: 100px;
-      height: 175px;
+      width: 100%;
+      aspect-ratio: 100 / 175;
       border-radius: 10px;
       overflow: hidden;
       cursor: pointer;
@@ -50,6 +51,26 @@
     button:disabled {
       background-color: #555;
       cursor: not-allowed;
+    }
+
+    @media (max-width: 600px) {
+      .cards {
+        grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+      }
+      button {
+        padding: 8px 16px;
+        font-size: 14px;
+      }
+    }
+
+    @media (max-width: 400px) {
+      .cards {
+        grid-template-columns: repeat(auto-fit, minmax(50px, 1fr));
+      }
+      button {
+        padding: 6px 12px;
+        font-size: 12px;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper scaling on mobile
- switch card grid to auto-fit layout and use relative card sizing
- adjust card and button sizes with new media queries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688de5c481508332b83667eb9c38fe4a