### PR TITLE
fix: remove duplicate render and reset cards before rerender

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,9 @@
   }
 
   function renderCards() {
+    cardsContainer.innerHTML = "";
+    selected.length = 0;
+    submitBtn.disabled = true;
     const shuffled = allCards.sort(() => 0.5 - Math.random()).slice(0, 9);
     shuffled.forEach(name => cardsContainer.appendChild(createCard(name)));
   }
@@ -201,8 +204,6 @@
       alert("Выбранные карты: " + card1 + ", " + card2);
     }
   };
-
-  renderCards();
 
   renderCards();
 </script>


### PR DESCRIPTION
## Summary
- remove duplicate invocation of `renderCards`
- clear and reset card selection before rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688de59cd2b48332abedfd38adec5016