### PR TITLE
feat: add two card combination lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,13 +216,25 @@
     const card1 = selected[0];
     const card2 = selected[1];
 
-    const data = { card1, card2 };
+    const key1 = `${card1}|${card2}`;
+    const key2 = `${card2}|${card1}`;
+    const interpretation = combinationsData[key1] || combinationsData[key2];
 
-    if (window.Telegram && Telegram.WebApp) {
-      Telegram.WebApp.sendData(JSON.stringify(data));
-      Telegram.WebApp.close();
+    if (interpretation) {
+      if (window.Telegram && Telegram.WebApp) {
+        Telegram.WebApp.sendData(interpretation);
+        Telegram.WebApp.close();
+      } else {
+        alert(interpretation);
+      }
     } else {
-      alert("Выбранные карты: " + card1 + ", " + card2);
+      const message = "К сожалению, эта комбинация не описана.";
+      if (window.Telegram && Telegram.WebApp) {
+        Telegram.WebApp.sendData(message);
+        Telegram.WebApp.close();
+      } else {
+        alert(message);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- look up two-card combinations using both order permutations
- alert or send interpretation to Telegram; show fallback when missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ded9925dc8332899132c81ff9f2cb