### PR TITLE
Restore `fetchWithTimeout` to fix two-card selection crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,6 +304,10 @@
   }
 
 
+  async function fetchWithTimeout(url, options = {}, timeoutMs = requestTimeoutMs) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
     try {
       return await fetch(url, {
         ...options,


### PR DESCRIPTION
### Motivation
- The inline script in `index.html` was missing the `fetchWithTimeout` helper which caused a JS runtime error that prevented the app from initializing and blocked selecting cards in the two-card reading flow.

### Description
- Restored `async function fetchWithTimeout(url, options = {}, timeoutMs = requestTimeoutMs)` (uses `AbortController` and `clearTimeout`) in `index.html`, so `getTwoCardReading` correctly calls `fetchWithTimeout` again and the two-card selection logic can initialize.

### Testing
- Performed a JavaScript syntax check by extracting the inline `<script>` and evaluating it with Node (`node -e "const fs=require('fs');const h=fs.readFileSync('index.html','utf8');const s=h.match(/<script>([\s\S]*)<\/script>/)[1];new Function(s);console.log('JS syntax OK')"`) and received `JS syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb77dc59d88332be4cd639ba1a7847)