### PR TITLE
Add request timeout, error parsing and realtime/backend fallback for readings

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,6 +304,10 @@
   }
 
 
+  async function fetchWithTimeout(url, options = {}, timeoutMs = requestTimeoutMs) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
     try {
       return await fetch(url, {
         ...options,
@@ -335,7 +339,14 @@
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(errorText || `Ошибка backend (${response.status})`);
+      let detail = errorText;
+      try {
+        const parsed = JSON.parse(errorText);
+        detail = typeof parsed.detail === "string" ? parsed.detail : errorText;
+      } catch (_) {
+        // ignore non-JSON body
+      }
+      throw new Error(detail || `Ошибка backend (${response.status})`);
     }
 
     const data = await response.json();
@@ -345,6 +356,35 @@
     }
 
     return reading;
+  }
+
+  async function getReadingWithFallback(firstCard, secondCard) {
+    const errors = [];
+
+    if (useRealtimeInterpretation) {
+      try {
+        return await getRealtimeInterpretation(firstCard, secondCard);
+      } catch (error) {
+        console.warn("Realtime трактовка недоступна, пробую backend", error);
+        errors.push(`realtime: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    try {
+      return await getTwoCardReading(firstCard, secondCard);
+    } catch (error) {
+      errors.push(`backend: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    if (!useRealtimeInterpretation && interpretationApiUrl) {
+      try {
+        return await getRealtimeInterpretation(firstCard, secondCard);
+      } catch (error) {
+        errors.push(`realtime-fallback: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    throw new Error(errors.join(" | "));
   }
 
   function createCard(name) {
@@ -392,11 +432,12 @@
     submitBtn.textContent = "⏳ Формирую трактовку...";
 
     try {
-      const reading = await getTwoCardReading(firstCard, secondCard);
+      const reading = await getReadingWithFallback(firstCard, secondCard);
       sendResult(reading);
     } catch (err) {
       console.error("Ошибка получения трактовки:", err);
-      sendResult("Не удалось получить трактовку сейчас. Попробуй снова через минуту.");
+      const details = err instanceof Error && err.message ? `\n\nДетали: ${err.message}` : "";
+      sendResult(`Не удалось получить трактовку сейчас. Попробуй снова через минуту.${details}`);
     } finally {
       updateUIState();
     }


### PR DESCRIPTION
### Motivation
- Prevent hanging network calls by enforcing a request timeout for reading APIs.
- Improve error diagnostics by parsing JSON error bodies from the backend.
- Increase reliability of readings by falling back between realtime interpretation and backend services.
- Surface actionable error details to the user when available.

### Description
- Add `fetchWithTimeout(url, options, timeoutMs)` that uses `AbortController` to enforce `requestTimeoutMs`.
- Update `getTwoCardReading` to use `fetchWithTimeout` and to try parsing JSON error responses for a `detail` field before throwing.
- Introduce `getReadingWithFallback` which attempts `getRealtimeInterpretation`, then `getTwoCardReading`, and optionally retries realtime as a fallback while aggregating error messages.
- Change the submit handler to call `getReadingWithFallback` and include available error details in the user-facing message from `sendResult`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb77dc59d88332be4cd639ba1a7847)