### PR TITLE
Fallback to Chat Completions on OpenAI 405/404 and sanitize backend error text in UI

### DIFF
--- a/backend/services/tarot_ai.py
+++ b/backend/services/tarot_ai.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from openai import APIConnectionError, APITimeoutError, OpenAI, RateLimitError
+from openai import APIConnectionError, APIStatusError, APITimeoutError, OpenAI, RateLimitError
 
 
 class TarotAIError(Exception):
@@ -55,6 +55,15 @@ class TarotAIService:
             topic=topic_value or "не указана",
         )
 
+        text = self._generate_with_responses_api(user_prompt)
+        if not text:
+            text = self._generate_with_chat_completions_api(user_prompt)
+        if not text:
+            raise TarotAIEmptyResponseError("OpenAI returned empty response")
+
+        return text
+
+    def _generate_with_responses_api(self, user_prompt: str) -> str:
         try:
             response = self.client.responses.create(
                 model=self.model,
@@ -63,13 +72,30 @@ class TarotAIService:
                     {"role": "user", "content": user_prompt},
                 ],
             )
+            return (response.output_text or "").strip()
         except (APITimeoutError, APIConnectionError, RateLimitError) as exc:
             raise TarotAIUnavailableError("OpenAI API is unavailable") from exc
+        except APIStatusError as exc:
+            if exc.status_code in {404, 405, 501}:
+                return ""
+            raise TarotAIUnavailableError(f"OpenAI API status error: {exc.status_code}") from exc
         except Exception as exc:  # pragma: no cover
             raise TarotAIUnavailableError("OpenAI API call failed") from exc
 
-        text = (response.output_text or "").strip()
-        if not text:
-            raise TarotAIEmptyResponseError("OpenAI returned empty response")
-
-        return text
+    def _generate_with_chat_completions_api(self, user_prompt: str) -> str:
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": self.system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            )
+            message = response.choices[0].message if response.choices else None
+            return (message.content or "").strip() if message else ""
+        except (APITimeoutError, APIConnectionError, RateLimitError) as exc:
+            raise TarotAIUnavailableError("OpenAI API is unavailable") from exc
+        except APIStatusError as exc:
+            raise TarotAIUnavailableError(f"OpenAI API status error: {exc.status_code}") from exc
+        except Exception as exc:  # pragma: no cover
+            raise TarotAIUnavailableError("OpenAI API call failed") from exc

--- a/index.html
+++ b/index.html
@@ -339,12 +339,16 @@
 
     if (!response.ok) {
       const errorText = await response.text();
-      let detail = errorText;
+      let detail = `Backend вернул ошибку (${response.status})`;
       try {
         const parsed = JSON.parse(errorText);
-        detail = typeof parsed.detail === "string" ? parsed.detail : errorText;
+        if (typeof parsed.detail === "string" && parsed.detail.trim()) {
+          detail = parsed.detail.trim();
+        }
       } catch (_) {
-        // ignore non-JSON body
+        if (!/<[^>]+>/.test(errorText) && errorText.trim()) {
+          detail = errorText.trim();
+        }
       }
       throw new Error(detail || `Ошибка backend (${response.status})`);
     }


### PR DESCRIPTION
### Motivation
- Some OpenAI-compatible upstreams/proxies return `405 Not Allowed` or other status codes for the Responses API, causing failures and showing raw HTML error pages in the web UI instead of a readable message.

### Description
- Added handling of `APIStatusError` and a two-step generation flow in `TarotAIService` that first tries `responses.create` and falls back to `chat.completions.create` when the Responses API is unsupported (e.g. status `404/405/501`) by using `_generate_with_responses_api` and `_generate_with_chat_completions_api` in `backend/services/tarot_ai.py`.
- Added explicit import of `APIStatusError` and mapped certain status codes to a graceful fallback instead of failing hard, while preserving other status errors as `TarotAIUnavailableError`.
- Improved frontend error parsing in `index.html` to show a concise status-based message `Backend вернул ошибку (<status>)`, prefer structured JSON `detail` if present, and avoid surfacing raw HTML pages by checking for HTML tags before displaying body text.

### Testing
- Ran `python3 -m compileall backend` and compilation completed successfully.
- No automated HTTP/integration tests were run in this change set; runtime behavior was addressed to recover from Responses-API `405`/`404` responses and to avoid leaking HTML error pages to users.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb86fb34008332a961f37933033099)