### PR TITLE
Add GET fallback for two-card readings and resilient OpenAI Responses API usage

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -51,8 +51,33 @@ def health() -> dict[str, str]:
 
 @app.post("/api/readings/two-cards", response_model=TwoCardReadingResponse)
 def create_two_card_reading(payload: TwoCardReadingRequest) -> TwoCardReadingResponse:
-    first_card = payload.first_card.strip()
-    second_card = payload.second_card.strip()
+    return _build_two_card_reading(
+        first_card=payload.first_card,
+        second_card=payload.second_card,
+        topic=payload.topic,
+    )
+
+
+@app.get("/api/readings/two-cards", response_model=TwoCardReadingResponse)
+def create_two_card_reading_get(
+    first_card: str = Query(..., min_length=1),
+    second_card: str = Query(..., min_length=1),
+    topic: Optional[str] = None,
+) -> TwoCardReadingResponse:
+    return _build_two_card_reading(
+        first_card=first_card,
+        second_card=second_card,
+        topic=topic,
+    )
+
+
+def _build_two_card_reading(
+    first_card: str,
+    second_card: str,
+    topic: Optional[str] = None,
+) -> TwoCardReadingResponse:
+    first_card = first_card.strip()
+    second_card = second_card.strip()
 
     if _is_duplicate_forbidden() and first_card == second_card:
         raise HTTPException(status_code=400, detail="Duplicate cards are not allowed")
@@ -65,7 +90,7 @@ def create_two_card_reading(payload: TwoCardReadingRequest) -> TwoCardReadingRes
         reading = service.generate_two_card_reading(
             first_card=first_card,
             second_card=second_card,
-            topic=payload.topic,
+            topic=topic,
         )
         return TwoCardReadingResponse(reading=reading, model=service.model)
     except TarotAIConfigError as exc:

--- a/backend/services/tarot_ai.py
+++ b/backend/services/tarot_ai.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from openai import APIConnectionError, APITimeoutError, OpenAI, RateLimitError
+from openai import APIConnectionError, APIStatusError, APITimeoutError, OpenAI, RateLimitError
 
 
 class TarotAIError(Exception):
@@ -55,6 +55,15 @@ class TarotAIService:
             topic=topic_value or "не указана",
         )
 
+        text = self._generate_with_responses_api(user_prompt)
+        if not text:
+            text = self._generate_with_chat_completions_api(user_prompt)
+        if not text:
+            raise TarotAIEmptyResponseError("OpenAI returned empty response")
+
+        return text
+
+    def _generate_with_responses_api(self, user_prompt: str) -> str:
         try:
             response = self.client.responses.create(
                 model=self.model,
@@ -63,13 +72,30 @@ class TarotAIService:
                     {"role": "user", "content": user_prompt},
                 ],
             )
+            return (response.output_text or "").strip()
         except (APITimeoutError, APIConnectionError, RateLimitError) as exc:
             raise TarotAIUnavailableError("OpenAI API is unavailable") from exc
+        except APIStatusError as exc:
+            if exc.status_code in {404, 405, 501}:
+                return ""
+            raise TarotAIUnavailableError(f"OpenAI API status error: {exc.status_code}") from exc
         except Exception as exc:  # pragma: no cover
             raise TarotAIUnavailableError("OpenAI API call failed") from exc
 
-        text = (response.output_text or "").strip()
-        if not text:
-            raise TarotAIEmptyResponseError("OpenAI returned empty response")
-
-        return text
+    def _generate_with_chat_completions_api(self, user_prompt: str) -> str:
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": self.system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            )
+            message = response.choices[0].message if response.choices else None
+            return (message.content or "").strip() if message else ""
+        except (APITimeoutError, APIConnectionError, RateLimitError) as exc:
+            raise TarotAIUnavailableError("OpenAI API is unavailable") from exc
+        except APIStatusError as exc:
+            raise TarotAIUnavailableError(f"OpenAI API status error: {exc.status_code}") from exc
+        except Exception as exc:  # pragma: no cover
+            raise TarotAIUnavailableError("OpenAI API call failed") from exc

--- a/index.html
+++ b/index.html
@@ -337,14 +337,39 @@
       })
     }, requestTimeoutMs);
 
+    if (!response.ok && response.status === 405) {
+      const getUrl = new URL(readingApiUrl, window.location.origin);
+      getUrl.searchParams.set("first_card", firstCard);
+      getUrl.searchParams.set("second_card", secondCard);
+
+      const getResponse = await fetchWithTimeout(getUrl.toString(), {
+        method: "GET",
+        headers: {
+          ...(readingApiToken ? { Authorization: `Bearer ${readingApiToken}` } : {})
+        }
+      }, requestTimeoutMs);
+
+      if (getResponse.ok) {
+        const fallbackData = await getResponse.json();
+        const fallbackReading = typeof fallbackData.reading === "string" ? fallbackData.reading.trim() : "";
+        if (fallbackReading) {
+          return fallbackReading;
+        }
+      }
+    }
+
     if (!response.ok) {
       const errorText = await response.text();
-      let detail = errorText;
+      let detail = `Backend вернул ошибку (${response.status})`;
       try {
         const parsed = JSON.parse(errorText);
-        detail = typeof parsed.detail === "string" ? parsed.detail : errorText;
+        if (typeof parsed.detail === "string" && parsed.detail.trim()) {
+          detail = parsed.detail.trim();
+        }
       } catch (_) {
-        // ignore non-JSON body
+        if (!/<[^>]+>/.test(errorText) && errorText.trim()) {
+          detail = errorText.trim();
+        }
       }
       throw new Error(detail || `Ошибка backend (${response.status})`);
     }


### PR DESCRIPTION
### Motivation
- Provide a GET-based API and frontend fallback so clients can obtain two-card readings when POST is blocked (HTTP 405) or simpler query usage is needed.
- Make the OpenAI integration more resilient by trying the newer Responses API and falling back to the Chat Completions API when Responses is unavailable or returns no text.

### Description
- Added a GET endpoint `/api/readings/two-cards` and refactored the POST handler into `_build_two_card_reading` to share validation and business logic, keeping duplicate-card and empty-card checks intact.
- Frontend `getTwoCardReading` now retries with a GET request when the POST returns `405`, trims and validates fallback reading, and improves error body parsing and user-facing error text.
- In `services/tarot_ai.py` imported `APIStatusError` and implemented `_generate_with_responses_api` that returns an empty string for certain status codes to allow fallback, and `_generate_with_chat_completions_api` as a secondary attempt, raising `TarotAIEmptyResponseError` only if both methods return empty.
- Improved exception handling for OpenAI errors to map API timeouts, connection errors, rate limits, and status errors to `TarotAIUnavailableError` with clearer messages.

### Testing
- Ran the backend unit test suite with `pytest` and the linter with `flake8`, and both completed successfully.
- Performed automated endpoint smoke tests calling both `POST /api/readings/two-cards` and `GET /api/readings/two-cards` to validate shared validation and successful fallback, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb86fb34008332a961f37933033099)